### PR TITLE
Replaced old image with the standard Docker library MySQL image.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ version: '2'
 services:
 
     mysql:
-      image: nexus.fcvhost.com/php/mysql55
+      image: mysql:5.5 
       ports:
           - 3306:3306
       expose:


### PR DESCRIPTION
This is to replace the old image which we are no longer using. Be sure to update your local images before proceeding, as you will run into access control issues if you do not.